### PR TITLE
Branch name with ‘#’ issue.

### DIFF
--- a/src/git.js
+++ b/src/git.js
@@ -20,7 +20,7 @@ function wrapBranchNameSafe (branchName) {
 }
 
 function replaceBranchNameForWeb (branchName) {
-  return branchName.replace('#', '%23')
+  return encodeURIComponent(branchName)
 }
 
 export default function GitSash (config) {


### PR DESCRIPTION
#7

- 브랜치 이름에 # 이 들어가는 경우 주석이 포함된 명령어가 shell 에 입력이 되어 원하는대로 동작하지 않던 버그 수정
- 이 경우 web에 pr을 위해 브라우저에서 브랜치 이름을 보여줄 때 브랜치 이름의 # 을 %23 으로 변경하도록 수정